### PR TITLE
Load relative to project

### DIFF
--- a/Sources/Configuration/ConfigurationManager.swift
+++ b/Sources/Configuration/ConfigurationManager.swift
@@ -62,6 +62,9 @@ public class ConfigurationManager {
         /// Relative from executable location
         case executable
 
+        /// Relative from project directory
+        case project
+
         /// Relative from present working directory (PWD)
         case pwd
 
@@ -75,6 +78,8 @@ public class ConfigurationManager {
                 return executableFolder
             case .pwd:
                 return presentWorkingDirectory
+            case .project:
+                return projectDirectory
             case .customPath(let path):
                 return path
             }

--- a/Sources/Configuration/Utilities.swift
+++ b/Sources/Configuration/Utilities.swift
@@ -16,8 +16,17 @@
 
 import Foundation
 
+/// Absolute URL to executable
+#if os(Linux)
+let executableURL = Bundle.main.executableURL
+                    ?? URL(fileURLWithPath: "/proc/self/exe").resolvingSymlinksInPath()
+#else
+let executableURL = Bundle.main.executableURL
+                    ?? URL(fileURLWithPath: CommandLine.arguments[0]).standardized
+#endif
+
 /// Absolute path to the executable's folder
-let executableFolder = URL(fileURLWithPath: CommandLine.arguments[0]).appendingPathComponent("..").standardized.path
+let executableFolder = executableURL.appendingPathComponent("..").standardized.path
 
 /// Absolute path to the present working directory (PWD)
 let presentWorkingDirectory = URL(fileURLWithPath: "").path

--- a/Sources/Configuration/Utilities.swift
+++ b/Sources/Configuration/Utilities.swift
@@ -28,5 +28,25 @@ let executableURL = Bundle.main.executableURL
 /// Absolute path to the executable's folder
 let executableFolder = executableURL.appendingPathComponent("..").standardized.path
 
+/// Directory containing the Package.swift of the project (as determined by traversing
+/// up the directory structure starting at the directory containing the executable), or
+/// if no Package.swift is found then the directory containing the executable
+func findProjectRoot() -> String {
+    let fileManager = FileManager()
+    var directory = executableURL
+    repeat {
+        directory.appendPathComponent("..")
+        directory.standardize()
+        let packageFilePath = directory.appendingPathComponent("Package.swift").path
+        if fileManager.fileExists(atPath: packageFilePath) {
+            return directory.path
+        }
+    } while directory.path != "/"
+    return executableFolder
+}
+
+/// Absolute path to the project directory
+let projectDirectory = findProjectRoot()
+
 /// Absolute path to the present working directory (PWD)
 let presentWorkingDirectory = URL(fileURLWithPath: "").path

--- a/Tests/ConfigurationTests/ConfigurationManagerTest.swift
+++ b/Tests/ConfigurationTests/ConfigurationManagerTest.swift
@@ -15,6 +15,7 @@
  */
 
 import XCTest
+import Foundation
 @testable import Configuration
 
 class ConfigurationManagerTest: XCTestCase {
@@ -22,7 +23,8 @@ class ConfigurationManagerTest: XCTestCase {
         return [
             ("testLoadSimple", testLoadSimple),
             ("testLoadFile", testLoadFile),
-            ("testLoadData", testLoadData)
+            ("testLoadData", testLoadData),
+            ("testLoadRelative", testLoadRelative)
         ]
     }
 
@@ -74,5 +76,27 @@ class ConfigurationManagerTest: XCTestCase {
 
         manager.load(data: jsonData)
         XCTAssertEqual(manager["hello"] as? String, "world")
+    }
+
+    func testLoadRelative() {
+        var manager = ConfigurationManager()
+        manager.load(file: "TestResources/test.json", relativeFrom: .project)
+        XCTAssertEqual(manager["OAuth:configuration:state"] as? Bool, true)
+
+        manager = ConfigurationManager()
+        manager.load(file: "../../TestResources/test.json", relativeFrom: .executable)
+        XCTAssertEqual(manager["OAuth:configuration:state"] as? Bool, true)
+
+        manager = ConfigurationManager()
+        manager.load(file: "../../../TestResources/test.json", relativeFrom: .customPath(executableFolder + "/dummy"))
+        XCTAssertEqual(manager["OAuth:configuration:state"] as? Bool, true)
+
+        manager = ConfigurationManager()
+        guard FileManager().changeCurrentDirectoryPath(executableFolder + "/..") else {
+            XCTFail("Failed to set working directory")
+            return
+        }
+        manager.load(file: "../TestResources/test.json", relativeFrom: .pwd)
+        XCTAssertEqual(manager["OAuth:configuration:state"] as? Bool, true)
     }
 }


### PR DESCRIPTION
This PR improves robustness of identifying executable location and adds support for BasePath.project which allows file loading relative to the project directory (location of the Package.swift as determined by traversing up the directory structure, starting from the executable folder, defaulting to the executable folder if not found).

It also includes unit tests for relative loading for each BasePath type.