### PR TITLE
Add relative load test in external program

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ import PackageDescription
 
 let package = Package(
     name: "Configuration",
+    targets: [ Target(name: "ExternalLoadTestProgram", dependencies: [ .Target(name: "Configuration") ]) ],
     dependencies: [
         .Package(url: "https://github.com/IBM-Swift/LoggerAPI.git", majorVersion: 1),
         ]

--- a/Sources/ExternalLoadTestProgram/main.swift
+++ b/Sources/ExternalLoadTestProgram/main.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Configuration
+
+let executableURL = Bundle.main.executableURL ?? URL(fileURLWithPath: CommandLine.arguments[0])
+let executableFolder = executableURL.appendingPathComponent("..").standardized.path
+var exitCode: Int32 = 0
+
+var manager = ConfigurationManager()
+manager.load(file: "TestResources/test.json", relativeFrom: .project)
+if manager["OAuth:configuration:state"] as? Bool == true {
+    print(".project: PASS")
+} else {
+    print(".project: FAIL")
+    exitCode = 1
+}
+
+manager = ConfigurationManager()
+manager.load(file: "../../TestResources/test.json", relativeFrom: .executable)
+if manager["OAuth:configuration:state"] as? Bool == true {
+    print(".executable: PASS")
+} else {
+    print(".executable: FAIL")
+    exitCode = 1
+}
+
+manager = ConfigurationManager()
+manager.load(file: "../../../TestResources/test.json", relativeFrom: .customPath(executableFolder + "/dummy"))
+if manager["OAuth:configuration:state"] as? Bool == true {
+    print(".customPath: PASS")
+} else {
+    print(".customPath: FAIL")
+    exitCode = 1
+}
+
+manager = ConfigurationManager()
+if FileManager().changeCurrentDirectoryPath(executableFolder + "/..") {
+manager.load(file: "../TestResources/test.json", relativeFrom: .pwd)
+    if manager["OAuth:configuration:state"] as? Bool == true {
+        print(".pwd: PASS")
+    } else {
+        print(".pwd: FAIL")
+        exitCode = 1
+    }
+} else {
+    print(".pwd: FAIL (working directory)")
+    exitCode = 1
+}
+
+exit(exitCode)


### PR DESCRIPTION
Pros: Tests the actual functionality you see when not running under XCTest.
Cons: Adds a non-Test module to the project that everyone will build to enable the test