### PR TITLE
Support executable location under XCTest runner

### DIFF
--- a/Sources/Configuration/Utilities.swift
+++ b/Sources/Configuration/Utilities.swift
@@ -16,24 +16,42 @@
 
 import Foundation
 
-/// Absolute URL to executable
+func executableFolderURL() -> URL {
 #if os(Linux)
-let executableURL = Bundle.main.executableURL
-                    ?? URL(fileURLWithPath: "/proc/self/exe").resolvingSymlinksInPath()
+    let actualExecutableURL = Bundle.main.executableURL
+                              ?? URL(fileURLWithPath: "/proc/self/exe").resolvingSymlinksInPath()
+    return actualExecutableURL.appendingPathComponent("..").standardized
 #else
-let executableURL = Bundle.main.executableURL
-                    ?? URL(fileURLWithPath: CommandLine.arguments[0]).standardized
+    let actualExecutableURL = Bundle.main.executableURL
+                              ?? URL(fileURLWithPath: CommandLine.arguments[0]).standardized
+    let actualExecutableFolderURL = actualExecutableURL.appendingPathComponent("..").standardized
+
+    if (Bundle.main.executableURL?.lastPathComponent != "xctest") {
+        return actualExecutableFolderURL
+    } else {
+        // We are running under the test runner, we may be able to work out the build directory that
+        // contains the test program which is testing libraries in the project. That build directory
+        // should also contain any executables associated with the project until this build type
+        // (eg: release or debug)
+        let loadedTestBundles = Bundle.allBundles.filter({ $0.isLoaded }).filter({ $0.bundlePath.hasSuffix(".xctest") })
+        if loadedTestBundles.count > 0 {
+            return loadedTestBundles[0].bundleURL.appendingPathComponent("..").standardized
+        } else {
+            return actualExecutableFolderURL
+        }
+    }
 #endif
+}
 
 /// Absolute path to the executable's folder
-let executableFolder = executableURL.appendingPathComponent("..").standardized.path
+let executableFolder = executableFolderURL().path
 
 /// Directory containing the Package.swift of the project (as determined by traversing
 /// up the directory structure starting at the directory containing the executable), or
 /// if no Package.swift is found then the directory containing the executable
 func findProjectRoot() -> String {
     let fileManager = FileManager()
-    var directory = executableURL
+    var directory = executableFolderURL().appendingPathComponent("dummy")
     repeat {
         directory.appendPathComponent("..")
         directory.standardize()


### PR DESCRIPTION
Finds the executable (build) directory when running under the XCTest runner on macOS (not needed on Linux -- the normal method works there).

This is useful to support loading config  relativeTo `.executable` or `.project` for your tests (on macOS).
This also fixes the failures in the new tests in `load_relative_to_project` / PR #12.