### PR TITLE
Improve tests

### DIFF
--- a/Sources/TestProgram/main.swift
+++ b/Sources/TestProgram/main.swift
@@ -54,4 +54,30 @@ else {
 
 testsExecuted += 1
 
+// test load file relative from executable
+manager = ConfigurationManager().load(file: "../../TestResources/test.json", relativeFrom: .executable)
+
+if manager["OAuth:configuration:state"] as? Bool == true {
+    print("Test Case '- [.executable]': PASS")
+}
+else {
+    print("Test Case '- [.executable]': FAIL")
+    exitCode += 1 << testsExecuted
+}
+
+testsExecuted += 1
+
+// test load file relative from project folder
+manager = ConfigurationManager().load(file: "TestResources/test.json", relativeFrom: .project)
+
+if manager["OAuth:configuration:state"] as? Bool == true {
+    print("Test Case '- [.executable]': PASS")
+}
+else {
+    print("Test Case '- [.executable]': FAIL")
+    exitCode += 1 << testsExecuted
+}
+
+testsExecuted += 1
+
 exit(exitCode)


### PR DESCRIPTION
Change unit tests to call the test executable in `<project_root>/.build` instead of the one generated by Xcode. Add more tests to test executable to cover more code.