### PR TITLE
Update tests; randomize test order

### DIFF
--- a/Tests/ConfigurationTests/ConfigurationManagerTest.swift
+++ b/Tests/ConfigurationTests/ConfigurationManagerTest.swift
@@ -21,7 +21,6 @@ import Foundation
 class ConfigurationManagerTest: XCTestCase {
     static var allTests : [(String, (ConfigurationManagerTest) -> () throws -> Void)] {
         return [
-            ("testLinuxTestSuiteIncludesAllTests", testLinuxTestSuiteIncludesAllTests),
             ("testLoadSimple", testLoadSimple),
             ("testLoadFile", testLoadFile),
             ("testLoadData", testLoadData),
@@ -79,15 +78,6 @@ class ConfigurationManagerTest: XCTestCase {
         process.waitUntilExit()
 
         return (errPipe, outPipe, process.terminationStatus)
-    }
-
-    func testLinuxTestSuiteIncludesAllTests() {
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-            let thisClass = type(of: self)
-            let linuxCount = thisClass.allTests.count
-            let darwinCount = Int(thisClass.defaultTestSuite().testCaseCount)
-            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from allTests")
-        #endif
     }
 
     func testLoadSimple() {

--- a/Tests/ConfigurationTests/ConfigurationNodeTest.swift
+++ b/Tests/ConfigurationTests/ConfigurationNodeTest.swift
@@ -20,21 +20,11 @@ import XCTest
 class ConfigurationNodeTest: XCTestCase {
     static var allTests : [(String, (ConfigurationNodeTest) -> () throws -> Void)] {
         return [
-            ("testLinuxTestSuiteIncludesAllTests", testLinuxTestSuiteIncludesAllTests),
             ("testRawValue", testRawValue),
             ("testSubscript", testSubscript),
             ("testMergeOverwrite", testMergeOverwrite),
             ("testSplitKeys", testSplitKeys)
         ]
-    }
-
-    func testLinuxTestSuiteIncludesAllTests() {
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-            let thisClass = type(of: self)
-            let linuxCount = thisClass.allTests.count
-            let darwinCount = Int(thisClass.defaultTestSuite().testCaseCount)
-            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from allTests")
-        #endif
     }
 
     func testRawValue() {

--- a/Tests/ConfigurationTests/LinuxSafeguardTest.swift
+++ b/Tests/ConfigurationTests/LinuxSafeguardTest.swift
@@ -1,0 +1,42 @@
+/*
+ * Copyright IBM Corporation 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// An extra test case to ensure that all other test cases include all of their
+// tests in their respective `allTests` variable. This is to ensure that the
+// same number of unit tests are executed on Linux as there are on OSX.
+//
+// Code adapted from https://oleb.net/blog/2017/03/keeping-xctest-in-sync/
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    import XCTest
+
+    class LinuxSafeguardTest: XCTestCase {
+        func testLinuxTestSuiteIncludesAllTests() {
+            var linuxCount: Int
+            var darwinCount: Int
+
+            // ConfigurationManagerTest
+            linuxCount = ConfigurationManagerTest.allTests.count
+            darwinCount = Int(ConfigurationManagerTest.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from ConfigurationManagerTest.allTests")
+
+            // ConfigurationNodeTest
+            linuxCount = ConfigurationNodeTest.allTests.count
+            darwinCount = Int(ConfigurationNodeTest.defaultTestSuite().testCaseCount)
+            XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from ConfigurationNodeTest.allTests")
+        }
+    }
+#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,48 @@
+/**
+ * Copyright IBM Corporation 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Glibc
 import XCTest
 @testable import ConfigurationTests
 
+// Implementation taken from http://stackoverflow.com/a/24029847
+extension MutableCollection where Indices.Iterator.Element == Index {
+    mutating func shuffle() {
+        let c = count
+        guard c > 1 else { return }
+
+        srand(UInt32(time(nil)))
+        for (firstUnshuffled , unshuffledCount) in zip(indices, stride(from: c, to: 1, by: -1)) {
+            let d: IndexDistance = numericCast(random() % numericCast(unshuffledCount))
+            guard d != 0 else { continue }
+            let i = index(firstUnshuffled, offsetBy: d)
+            swap(&self[firstUnshuffled], &self[i])
+        }
+    }
+}
+
+extension Sequence {
+    func shuffled() -> [Iterator.Element] {
+        var result = Array(self)
+        result.shuffle()
+        return result
+    }
+}
+
 XCTMain([
-    testCase(ConfigurationNodeTest.allTests),
-    testCase(ConfigurationManagerTest.allTests),
-])
+    testCase(ConfigurationNodeTest.allTests.shuffled()),
+    testCase(ConfigurationManagerTest.allTests.shuffled()),
+].shuffled())


### PR DESCRIPTION
Improving on #25 to randomize test order for IBM-Swift/Kitura#1056