### PR TITLE
Move load env var test from TestProgram to XCTest on macOS only

### DIFF
--- a/Sources/TestProgram/main.swift
+++ b/Sources/TestProgram/main.swift
@@ -31,6 +31,8 @@ var testsExecuted: Int32 = 0
 var manager: ConfigurationManager
 
 // test load env
+// Cannot be tested in XCTest on Linux due to https://bugs.swift.org/browse/SR-5076
+#if os(Linux)
 manager = ConfigurationManager().load(.environmentVariables)
 
 if manager["ENV:OAuth:configuration:state"] as? Bool == true {
@@ -42,6 +44,7 @@ else {
 }
 
 testsExecuted += 1
+#endif
 
 // test load file relative from executable
 manager = ConfigurationManager().load(file: "../../Tests/ConfigurationTests/test.json", relativeFrom: .executable)

--- a/Tests/ConfigurationTests/ConfigurationManagerTest.swift
+++ b/Tests/ConfigurationTests/ConfigurationManagerTest.swift
@@ -23,6 +23,7 @@ class ConfigurationManagerTest: XCTestCase {
         return [
             ("testLoadSimple", testLoadSimple),
             ("testLoadArgv", testLoadArgv),
+            ("testLoadEnvVar", testLoadEnvVar),
             ("testLoadData", testLoadData),
             ("testLoadFile", testLoadFile),
             ("testLoadRelative", testLoadRelative),
@@ -92,10 +93,26 @@ class ConfigurationManagerTest: XCTestCase {
 
         let manager = ConfigurationManager().load(.commandLineArguments)
 
-        XCTAssert(manager["argv:OAuth:configuration:state"] as? Bool == true)
+        XCTAssertEqual(manager["argv:OAuth:configuration:state"] as? Bool, true)
 
         // Clean up CommandLine.arguments
         CommandLine.arguments.removeLast()
+    }
+
+    func testLoadEnvVar() {
+        // Does not work in Linux yet due to https://bugs.swift.org/browse/SR-5076
+
+        #if os(macOS)
+            // Set env var
+            XCTAssertEqual(setenv("ENV", jsonString, 1), 0)
+
+            let manager = ConfigurationManager().load(.environmentVariables)
+
+            XCTAssertEqual(manager["ENV:OAuth:configuration:state"] as? Bool, true)
+
+            // Unset env var
+            XCTAssertEqual(unsetenv("ENV"), 0)
+        #endif
     }
 
     func testLoadSimple() {


### PR DESCRIPTION
For #23 