### PR TITLE
removed Logger from package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,6 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/IBM-Swift/FileKit.git", .upToNextMajor(from: "0.0.1"))
     ],
     targets: [
@@ -38,7 +37,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "Configuration",
-            dependencies: ["LoggerAPI", "FileKit"]
+            dependencies: ["FileKit"]
         ),
         .testTarget(
             name: "ConfigurationTests",


### PR DESCRIPTION
## Description
Logger was brought in Filekit and so does not need to be explicitly declared in the package.swift file.

## How Has This Been Tested?
Swift test was run and all tests pass. This change should have no impact of code functionality.
