### PR TITLE
Fix broken URLSession on Linux platform

### DIFF
--- a/Sources/Configuration/ConfigurationManager.swift
+++ b/Sources/Configuration/ConfigurationManager.swift
@@ -15,6 +15,9 @@
  */
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import LoggerAPI
 import FileKit
 

--- a/Sources/Configuration/ConfigurationManager.swift
+++ b/Sources/Configuration/ConfigurationManager.swift
@@ -15,8 +15,10 @@
  */
 
 import Foundation
-#if canImport(FoundationNetworking)
-import FoundationNetworking
+#if swift(>=4.1)
+  #if canImport(FoundationNetworking)
+    import FoundationNetworking
+  #endif
 #endif
 import LoggerAPI
 import FileKit


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`Configuration` module no longer builds on Linux since `URLSession` type is extracted from `Foundation` framework to a separate one `FoundationNetworking`

**UPDATE** Just realized this fix is required for Swift version <= 5.1. Current official release 5.0.1 does not support `#canImport` directive and there's no `FoundationNetworking` submodule yet.

## Motivation and Context
I use Configuration in one of my pet project and recently noticed that build fails due to above issue.

## How Has This Been Tested?
Ran automated tests.

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
