### PR TITLE
URLSession import fix

### DIFF
--- a/Sources/Configuration/ConfigurationManager.swift
+++ b/Sources/Configuration/ConfigurationManager.swift
@@ -15,10 +15,8 @@
  */
 
 import Foundation
-#if swift(>=4.1)
-  #if canImport(FoundationNetworking)
-    import FoundationNetworking
-  #endif
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
 #endif
 import LoggerAPI
 import FileKit


### PR DESCRIPTION
Trying to fix URLSession move to `FoundationNetworking`

## Description
Getting the flowing error on the latest version of Configuration, even though I am using Swift 5.1.1 version.

```!Swift
        [821/832] Compiling Configuration ConfigurationManager.swift
        /workspace/.build/checkouts/Configuration/Sources/Configuration/ConfigurationManager.swift:56:27: error: 'URLSession' is unavailable: This type has moved to the FoundationNetworking module. Import that module to use it.
            private let session = URLSession(configuration: URLSessionConfiguration.default)
                                  ^~~~~~~~~~
        Foundation.URLSession:2:18: note: 'URLSession' has been explicitly marked unavailable here
        public typealias URLSession = AnyObject
```

## Motivation and Context
Trying to fix URLSession move to `FoundationNetworking`
